### PR TITLE
fix: 🚚 update nrfconnect repository location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM coderbyheart/sdk-nrf-docker:latest
+FROM coderbyheart/fw-nrfconnect-nrf-docker:latest
 RUN rm -rf /workdir/ncs
 COPY . /workdir/ncs/firmware
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM coderbyheart/fw-nrfconnect-nrf-docker:latest
+FROM coderbyheart/sdk-nrf-docker:latest
 RUN rm -rf /workdir/ncs
 COPY . /workdir/ncs/firmware
 RUN \

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
-This application is built with [fw-nrfconnect-nrf](https://github.com/NordicPlayground/fw-nrfconnect-nrf).
+This application is built with [sdk-nrf](https://github.com/nrfconnect/sdk-nrf).
 
 Used to test NAT timeouts in different networks, sends messages to [NAT-TestServer](https://github.com/NordicSemiconductor/NAT-TestServer).
 

--- a/west.yml
+++ b/west.yml
@@ -1,7 +1,7 @@
 manifest:
   remotes:
     - name: nordic
-      url-base: https://github.com/NordicPlayground
+      url-base: https://github.com/nrfconnect
   projects:
     - name: sdk-nrf
       path: nrf

--- a/west.yml
+++ b/west.yml
@@ -3,7 +3,7 @@ manifest:
     - name: nordic
       url-base: https://github.com/NordicPlayground
   projects:
-    - name: fw-nrfconnect-nrf
+    - name: sdk-nrf
       path: nrf
       remote: nordic
       revision: a8a46cab54c402db76ba9c309636cfa52785b5ad


### PR DESCRIPTION
The nRF Connect repositories have been moved to [a separate GitHub organization](https://github.com/nrfconnect).
This updates the location and project names used in this repository.