### PR TITLE
docs: device shall not move

### DIFF
--- a/adr/001-stationary-during-tests.md
+++ b/adr/001-stationary-during-tests.md
@@ -1,0 +1,5 @@
+# Stationary during tests
+
+The device shall not move during tests.
+
+This is to ensure that longer running tests (like NAT timeout determination) are not affected by different properties of different network cells.


### PR DESCRIPTION
This documents that devices should be stationary during tests in form of an [Architectural Decision Record](https://www.youtube.com/watch?v=rwfXkSjFhzc).